### PR TITLE
Mentor notes for 'Pangram' in Haskell

### DIFF
--- a/tracks/haskell/exercises/pangram/README.md
+++ b/tracks/haskell/exercises/pangram/README.md
@@ -1,0 +1,27 @@
+### Reasonable solutions
+
+```haskell
+import Data.Char (isLetter, toLower)
+import qualified Data.Set as Set
+
+isPangram :: String -> Bool
+isPangram xs = Set.size (Set.fromList [toLower x | x <- xs, isLetter x]) == 26
+```
+
+### Common suggestions
+- Most solutions seem to start on `nub`, which has notoriously bad performance.
+Suggest trying the function on longer strings and then going for a better data
+structure than lists for keeping track of the `Set` (hint, hint) of seen
+characters.
+
+### Talking points
+- How to benchmark solutions, e.g. for telling if `nub` is really slow? Mention
+that GHCi can be useful here; it can print basic memory and timing statistics
+after entering
+```
+:set +s
+```
+...and then trying to check a very long string, e.g.
+```
+isPangram (replicate 10000000 'x')
+```


### PR DESCRIPTION
This is a write-up of my personal notes of things to consider when
reviewing Haskell solutions to the 'Pangram' exercise. The structure of
the document is largely based on the notes document for the Isogram
exercise in the Ruby track.

At this point, there isn't a lot of meat here: the single most common
issue with submissions is the usage of `nub`.