### PR TITLE
Mentor notes for 'Phone Number' exercise in Haskell

### DIFF
--- a/tracks/haskell/exercises/phone-number/README.md
+++ b/tracks/haskell/exercises/phone-number/README.md
@@ -1,0 +1,15 @@
+### Reasonable solutions
+
+```haskell
+import Data.Char (isDigit)
+
+number :: String -> Maybe String
+number xs = case filter isDigit xs of
+    ns@[     n,_,_, n',_,_, _,_,_,_] | all (> '1') [n, n'] -> Just ns
+    ns@['1', n,_,_, n',_,_, _,_,_,_] | all (> '1') [n, n'] -> Just (tail ns)
+    _                                                      -> Nothing
+```
+
+### Common suggestions
+- Most submissions attempt to parse the input string, but Haskell's pattern
+matching can be put to good use here!


### PR DESCRIPTION
This is a write-up of my personal notes of things to consider when
reviewing Haskell solutions to the 'Phone Number' exercise. The
structure of the document is largely based on the notes document for the
Isogram exercise in the Ruby track.

At this point, there isn't a lot of meat here: most submissions seem to
attempt to parse an input string, but the problem lends itself to
pattern-matching, which is a useful technique for simple parsing needs.