### PR TITLE
Add Ruby accumulate solutions without `map`

### DIFF
--- a/tracks/ruby/exercises/accumulate/README.md
+++ b/tracks/ruby/exercises/accumulate/README.md
@@ -1,13 +1,77 @@
-### Reasonable Solutions
+# Accumulate
+
+This exercise is asking you to re-implement `Array#map`. The goal is to get a
+feel for what's happening under the hood.
+
+## Reasonable Solutions
+
+There are 4 general classes of solutions that fall in a matrix
+`(functional | imperative) X ( high-level | low-level)`.
 
 ```ruby
+# High-level functional
+
 class Array
   def accumulate
-    map { |i| yield(i) }
+    reduce([]) { |arr, item| arr.append(yield item) }
+  end
+end
+```
+
+```ruby
+# High-level imperative
+
+class Array
+  def accumulate
+    result = []
+    each { |item| result << (yield item) }
+    result
+  end
+end
+```
+
+```ruby
+# Low-level functional
+# recursion
+
+class Array
+  def accumulate(accumulator = [], &block)
+    if empty?
+      accumulator
+    else
+      first, *rest = self
+      rest.accumulate(accumulator.append(yield first), &block)
+    end
+  end
+end
+```
+
+```ruby
+# Low-level imperative
+# for loops
+
+class Array
+  def accumulate
+    result = []
+    for item in self do
+      result << (yield item)
+    end
+    result
   end
 end
 ```
 
 ### Talking Points
 - Block syntax (`yield` vs `block.call`)
-- `map` vs `each` with an object
+- All `Enumerable` methods can be implemented in terms of `each` or `reduce`
+- High vs low-level approaches
+- Functional vs imperative
+
+### Restrictions
+
+Note that the student should _not_ use `Array#map` here as that defeats the
+purpose of this exercise. From the instructions:
+
+> Keep your hands off that collect/map/fmap/whatchamacallit functionality
+> provided by your standard library! Solve this one yourself using other basic
+> tools instead.


### PR DESCRIPTION
The current suggested solution for "Accumulate" just delegates to
`Array#map`. The exercise instructions explicitly say not to do this.

I've replaced the suggested example with 4 general approaches based on a
conversation that occurred in the mentors Slack back when Exercism 2.0
first launched.