### PR TITLE
Update ruby/clock example solution to match style guide

### DIFF
--- a/tracks/ruby/exercises/clock/README.md
+++ b/tracks/ruby/exercises/clock/README.md
@@ -17,7 +17,7 @@ class Clock
   end
 
   def to_s
-    "%02d:%02d" % time.divmod(MINUTES_PER_HOUR)
+    format("%02d:%02d", *time.divmod(MINUTES_PER_HOUR))
   end
 
   def +(other)
@@ -34,7 +34,7 @@ class Clock
   alias eql? ==
 
   def hash
-    [self.class, self.time].hash
+    [self.class, time].hash
   end
 
   protected


### PR DESCRIPTION
The [ruby style guide](https://github.com/rubocop-hq/ruby-style-guide#sprintf) currently suggests to use `format` or `sprintf` instead of `String#%`.

In addition, the `self` in the hash method is redundant, the [style guide](https://github.com/rubocop-hq/ruby-style-guide#no-self-unless-required) also recommends not including it here.