### PR TITLE
Ruby/Acronym Adjust for promotion to core exercise

### DIFF
--- a/tracks/ruby/exercises/acronym/readme.md
+++ b/tracks/ruby/exercises/acronym/readme.md
@@ -1,6 +1,6 @@
 # Acronym
 
-_Acronym_ is one of the first side exercises, unlocked by _TwoFer_
+_Acronym_ is promoted to a core exercise, the first after _TwoFer_. 
 
 ## Reasonable Solutions
 
@@ -11,6 +11,8 @@ module Acronym
   end
 end
 ```
+with variations for the regex (see below).
+
 
 ## Common suggestions
 * Most first submissions split the phrase into words with `String#split`: 


### PR DESCRIPTION
As an experiment, Acronym will be promoted to a core exercise. See https://github.com/exercism/ruby/pull/874 for more detail.

This updates the readme accordingly.